### PR TITLE
Fix includes, cmake find-package(kodi) and get addon.xml inline with other add-ons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 # --- Add-on Dependencies ------------------------------------------------------
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(kodiplatform REQUIRED)
 find_package(LibUSB REQUIRED)
 

--- a/peripheral.steamcontroller/addon.xml.in
+++ b/peripheral.steamcontroller/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="peripheral.steamcontroller"
-  version="1.0.0"
+  version="1.1.0"
   name="Steam controller driver"
   provider-name="Team-Kodi">
   <requires>

--- a/peripheral.steamcontroller/addon.xml.in
+++ b/peripheral.steamcontroller/addon.xml.in
@@ -11,15 +11,11 @@
   <extension
     point="kodi.peripheral"
     provides_joysticks="true"
-    library_linux="peripheral.steamcontroller.so"
-    library_osx="peripheral.steamcontroller.dylib"
-    library_wingl="peripheral.steamcontroller.dll"
-    library_windx="peripheral.steamcontroller.dll"
-    library_android="libperipheral.steamcontroller.so" />
+    library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en">Steam controller driver</summary>
     <description lang="en">This driver enables input from the Steam controller.</description>
-    <platform>all</platform>
+    <platform>@PLATFORM@</platform>
     <nofanart>true</nofanart>
   </extension>
 </addon>

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -20,8 +20,8 @@
 
 #define PERIPHERAL_ADDON_JOYSTICKS
 
-#include "kodi/xbmc_addon_dll.h"
-#include "kodi/kodi_peripheral_dll.h"
+#include "xbmc_addon_dll.h"
+#include "kodi_peripheral_dll.h"
 
 extern "C"
 {


### PR DESCRIPTION
https://github.com/kodi-game/peripheral.steamcontroller/commit/15e09e451f2af3e73ca15a79526b3be64281713f is needed after https://github.com/xbmc/xbmc/pull/9750 goes in

Expect 59 other PRs for game.libretro.\* add-ons changing addon.xml to addon.xml.in
They're ready but its way too late here to review.
