### PR TITLE
[depends] build libusb with pic

### DIFF
--- a/depends/common/libusb/CMakeLists.txt
+++ b/depends/common/libusb/CMakeLists.txt
@@ -12,6 +12,7 @@ ExternalProject_Add(
                             --disable-shared
                             --disable-examples-build
                             --disable-tests-build
+                            --with-pic
     INSTALL_COMMAND     ""
     BUILD_IN_SOURCE     1
 )


### PR DESCRIPTION
Before it brought always:
```
/usr/bin/ld: $HOME/Development/Kodi/addons/build/depends/lib/libusb-1.0.a(libusb_1_0_la-core.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: schlechter Wert
collect2: error: ld returned 1 exit status
make[5]: *** [CMakeFiles/peripheral.steamcontroller.dir/build.make:280: peripheral.steamcontroller.so.0.10.0] Fehler 1
make[4]: *** [CMakeFiles/Makefile2:73: CMakeFiles/peripheral.steamcontroller.dir/all] Fehler 2
make[3]: *** [Makefile:130: all] Fehler 2
make[2]: *** [CMakeFiles/peripheral.steamcontroller.dir/build.make:113: peripheral.steamcontroller-prefix/src/peripheral.steamcontroller-stamp/peripheral.steamcontroller-build] Fehler 2
make[1]: *** [CMakeFiles/Makefile2:7669: CMakeFiles/peripheral.steamcontroller.dir/all] Fehler 2
make: *** [Makefile:84: all] Fehler 2
```

by use of:
```
cmake -DCMAKE_BUILD_TYPE=Debug \
      -DCMAKE_INSTALL_PREFIX=/home/alwin/Development/Kodi/build/addons \
      -DPACKAGE_ZIP=1 \
      /home/alwin/Development/Kodi/kodi/cmake/addons \
      -DADDONS_TO_BUILD=peripheral.steamcontroller
make
```

I could not test the addon, but since it has no code changes, I think it still works.