### PR TITLE
fix possible crash during Kodi stop

### DIFF
--- a/peripheral.steamcontroller/addon.xml.in
+++ b/peripheral.steamcontroller/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="peripheral.steamcontroller"
-  version="20.0.1"
+  version="20.0.2"
   name="Steam controller driver"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>

--- a/src/usb/USBThread.cpp
+++ b/src/usb/USBThread.cpp
@@ -35,11 +35,14 @@ CUSBThread::~CUSBThread()
 void CUSBThread::Deinitialize()
 {
   m_isStopped = true;
-  if (m_thread->joinable())
-    m_thread->join();
+  if (m_thread)
+  {
+    if (m_thread->joinable())
+      m_thread->join();
 
-  delete m_thread;
-  m_thread = nullptr;
+    delete m_thread;
+    m_thread = nullptr;
+  }
 }
 
 void CUSBThread::RegisterDeviceHandle(CUSBDeviceHandle* deviceHandle)


### PR DESCRIPTION
On Kodi's exits was come a excpetion fault in case addon was not used complete.
This add a fix about.

The backtrace before:
```
Thread 1 "kodi.bin" received signal SIGSEGV, Segmentation fault.
0x0000555557550972 in std::thread::joinable (this=0x0) at /usr/include/c++/11/bits/std_thread.h:176
176	    { return !(_M_id == id()); }
(gdb) bt
#0  0x0000555557550972 in std::thread::joinable() const (this=0x0) at /usr/include/c++/11/bits/std_thread.h:176
#1  0x00007fff981415dd in STEAMCONTROLLER::CUSBThread::Deinitialize() (this=0x555559ef6fd0)
    at /home/alwin/Development/Kodi/_Addons/_alwin/peripheral/peripheral.steamcontroller/src/usb/USBThread.cpp:38
#2  0x00007fff9813a428 in STEAMCONTROLLER::CUSBContext::Deinitialize() (this=0x5555597b97c0)
    at /home/alwin/Development/Kodi/_Addons/_alwin/peripheral/peripheral.steamcontroller/src/usb/USBContext.cpp:51
#3  0x00007fff98134b8e in STEAMCONTROLLER::CSteamControllerManager::Deinitialize() (this=0x7fff98181720 <STEAMCONTROLLER::CSteamControllerManager::Get()::instance>)
    at /home/alwin/Development/Kodi/_Addons/_alwin/peripheral/peripheral.steamcontroller/src/steamcontroller/SteamControllerManager.cpp:45
#4  0x00007fff9814661e in CPeripheralSteamController::~CPeripheralSteamController() (this=0x55555aee5260, __in_chrg=<optimized out>)
    at /home/alwin/Development/Kodi/_Addons/_alwin/peripheral/peripheral.steamcontroller/src/addon.cpp:37
#5  0x00007fff98146664 in CPeripheralSteamController::~CPeripheralSteamController() (this=0x55555aee5260, __in_chrg=<optimized out>)
    at /home/alwin/Development/Kodi/_Addons/_alwin/peripheral/peripheral.steamcontroller/src/addon.cpp:38
#6  0x00007fff98147643 in kodi::addon::CAddonBase::ADDONBASE_Destroy(void*) (hdl=0x55555aee5260)
    at /home/alwin/Development/Kodi/_Addons/_alwin/peripheral/peripheral.steamcontroller/build/build/depends/include/kodi/../kodi/addon-instance/../AddonBase.h:756
#7  0x00005555579cc555 in ADDON::CAddonDll::Destroy() (this=0x55555a9acf00) at /home/alwin/Development/Kodi/kodi-N/xbmc/addons/binary-addons/AddonDll.cpp:222
#8  0x00005555579cc931 in ADDON::CAddonDll::DestroyInstance(KODI_ADDON_INSTANCE_STRUCT*) (this=0x55555a9acf00, instance=0x55555ac14320)
    at /home/alwin/Development/Kodi/kodi-N/xbmc/addons/binary-addons/AddonDll.cpp:281
#9  0x00005555579d385c in ADDON::IAddonInstanceHandler::DestroyInstance() (this=0x55555ac142e0)
    at /home/alwin/Development/Kodi/kodi-N/xbmc/addons/binary-addons/AddonInstanceHandler.cpp:127
#10 0x0000555557f5d070 in PERIPHERALS::CPeripheralAddon::DestroyAddon() (this=0x55555ac142e0) at /home/alwin/Development/Kodi/kodi-N/xbmc/peripherals/addons/PeripheralAddon.cpp:144
#11 0x0000555557f42bfc in PERIPHERALS::CPeripheralBusAddon::~CPeripheralBusAddon() (this=0x55555ad58f50, __in_chrg=<optimized out>)
    at /home/alwin/Development/Kodi/kodi-N/xbmc/peripherals/bus/virtual/PeripheralBusAddon.cpp:47
#12 0x0000555557f82f65 in __gnu_cxx::new_allocator<PERIPHERALS::CPeripheralBusAddon>::destroy<PERIPHERALS::CPeripheralBusAddon>(PERIPHERALS::CPeripheralBusAddon*)
    (this=0x55555ad58f50, __p=0x55555ad58f50) at /usr/include/c++/11/ext/new_allocator.h:168
#13 0x0000555557f82e5d in std::allocator_traits<std::allocator<PERIPHERALS::CPeripheralBusAddon> >::destroy<PERIPHERALS::CPeripheralBusAddon>(std::allocator<PERIPHERALS::CPeripheralBusAddon>&, PERIPHERALS::CPeripheralBusAddon*) (__a=..., __p=0x55555ad58f50) at /usr/include/c++/11/bits/alloc_traits.h:531
#14 0x0000555557f824c7 in std::_Sp_counted_ptr_inplace<PERIPHERALS::CPeripheralBusAddon, std::allocator<PERIPHERALS::CPeripheralBusAddon>, (__gnu_cxx::_Lock_policy)2>::_M_dispose()
    (this=0x55555ad58f40) at /usr/include/c++/11/bits/shared_ptr_base.h:528
#15 0x0000555556ddfdad in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() (this=0x55555ad58f40) at /usr/include/c++/11/bits/shared_ptr_base.h:168
#16 0x0000555556dda5cf in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() (this=0x55555af069d8, __in_chrg=<optimized out>)
    at /usr/include/c++/11/bits/shared_ptr_base.h:705
#17 0x0000555557f75850 in std::__shared_ptr<PERIPHERALS::CPeripheralBus, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() (this=0x55555af069d0, __in_chrg=<optimized out>)
    at /usr/include/c++/11/bits/shared_ptr_base.h:1154
#18 0x0000555557f75870 in std::shared_ptr<PERIPHERALS::CPeripheralBus>::~shared_ptr() (this=0x55555af069d0, __in_chrg=<optimized out>) at /usr/include/c++/11/bits/shared_ptr.h:122
#19 0x0000555557f7c9b6 in std::_Destroy<std::shared_ptr<PERIPHERALS::CPeripheralBus> >(std::shared_ptr<PERIPHERALS::CPeripheralBus>*) (__pointer=0x55555af069d0)
    at /usr/include/c++/11/bits/stl_construct.h:140
#20 0x0000555557f7b34a in std::_Destroy_aux<false>::__destroy<std::shared_ptr<PERIPHERALS::CPeripheralBus>*>(std::shared_ptr<PERIPHERALS::CPeripheralBus>*, std::shared_ptr<PERIPHERALS::CPeripheralBus>*) (__first=0x55555af069d0, __last=0x55555af069f0) at /usr/include/c++/11/bits/stl_construct.h:152
#21 0x0000555557f79698 in std::_Destroy<std::shared_ptr<PERIPHERALS::CPeripheralBus>*>(std::shared_ptr<PERIPHERALS::CPeripheralBus>*, std::shared_ptr<PERIPHERALS::CPeripheralBus>*)
    (__first=0x55555af069b0, __last=0x55555af069f0) at /usr/include/c++/11/bits/stl_construct.h:185
#22 0x0000555557f778ef in std::_Destroy<std::shared_ptr<PERIPHERALS::CPeripheralBus>*, std::shared_ptr<PERIPHERALS::CPeripheralBus> >(std::shared_ptr<PERIPHERALS::CPeripheralBus>*, std::shared_ptr<PERIPHERALS::CPeripheralBus>*, std::allocator<std::shared_ptr<PERIPHERALS::CPeripheralBus> >&) (__first=0x55555af069b0, __last=0x55555af069f0)
    at /usr/include/c++/11/bits/alloc_traits.h:746
#23 0x0000555557f781ef in std::vector<std::shared_ptr<PERIPHERALS::CPeripheralBus>, std::allocator<std::shared_ptr<PERIPHERALS::CPeripheralBus> > >::_M_erase_at_end(std::shared_ptr<PERIPHERALS::CPeripheralBus>*) (this=0x7fffffffdbe0, __pos=0x55555af069b0) at /usr/include/c++/11/bits/stl_vector.h:1796
#24 0x0000555557f7660a in std::vector<std::shared_ptr<PERIPHERALS::CPeripheralBus>, std::allocator<std::shared_ptr<PERIPHERALS::CPeripheralBus> > >::clear() (this=0x7fffffffdbe0)
    at /usr/include/c++/11/bits/stl_vector.h:1499
#25 0x0000555557f6f669 in PERIPHERALS::CPeripherals::Clear() (this=0x55555947efd0) at /home/alwin/Development/Kodi/kodi-N/xbmc/peripherals/Peripherals.cpp:156
#26 0x0000555557bc5fc3 in CServiceManager::DeinitStageThree() (this=0x555559385d20) at /home/alwin/Development/Kodi/kodi-N/xbmc/ServiceManager.cpp:223
#27 0x0000555557afdc8e in CApplication::Cleanup() (this=0x5555592d9440) at /home/alwin/Development/Kodi/kodi-N/xbmc/Application.cpp:2363
#28 0x0000555557bf4a13 in CXBApplicationEx::Destroy() (this=0x5555592d9440) at /home/alwin/Development/Kodi/kodi-N/xbmc/XBApplicationEx.cpp:35
#29 0x0000555557bf4c1d in CXBApplicationEx::Run(CAppParamParser const&) (this=0x5555592d9440, params=...) at /home/alwin/Development/Kodi/kodi-N/xbmc/XBApplicationEx.cpp:82
#30 0x0000555557649f69 in XBMC_Run(bool, CAppParamParser const&) (renderGUI=true, params=...) at /home/alwin/Development/Kodi/kodi-N/xbmc/platform/xbmc.cpp:64
#31 0x0000555556dd5e28 in main(int, char**) (argc=1, argv=0x7fffffffe038) at /home/alwin/Development/Kodi/kodi-N/xbmc/platform/posix/main.cpp:69
```